### PR TITLE
[ios] Correctly handle L train when populating `shapeToHeadSign`

### DIFF
--- a/Sources/MTAStation.swift
+++ b/Sources/MTAStation.swift
@@ -114,6 +114,15 @@ func loadTripsFromCSV() -> [String: String] {
       if let shapeID = row["shape_id"] as? String,
         let tripHeadSign = row["trip_headsign"] as? String
       {
+
+        // HACK: We had a mismatch between `shape_id` in static GTFS data and `shape_id`
+        // in realtime GTFS data for the L train. The static data had eg `L..N02R` whereas
+        // the realtime data had just `L..N`.
+        if shapeID.hasPrefix("L..") {
+          shapeToHeadSign[String(shapeID.prefix(4))] = tripHeadSign
+          continue
+        }
+
         shapeToHeadSign[shapeID] = tripHeadSign
       }
     }


### PR DESCRIPTION
We had a mismatch here because the static data had `shape_id` for the L train looking like eg `L..N02R` whereas the realtime GTFS data just had `L..N`. I don't believe this issue exists for other lines, but I'll double check.

We introduce a "hack" to `loadTripsFromCSV()` to handle populating `shapeToHeadSign` correctly so it matches data from realtime feed. We're basically just dropping everything past `L..[N/S]`... which doesn't seem great but it works and will always show correct terminal station (as of current static data) for L for now.