### PR TITLE
Optimize station list rendering

### DIFF
--- a/Sources/Views/StationSelectionSheet.swift
+++ b/Sources/Views/StationSelectionSheet.swift
@@ -27,8 +27,14 @@ struct StationSelectionSheet: View {
     }
   }
 
-  var sortedStationEntries: [StationWithDistance] {
-    guard let location else { return [] }
+  @State private var sortedStationEntries: [StationWithDistance] = []
+
+  func updateSortedStationEntries() {
+    guard let location else {
+      sortedStationEntries = []
+      return
+    }
+
     let stationDistances = filteredStationEntries.map { station in
       StationWithDistance(
         station: station,
@@ -36,7 +42,7 @@ struct StationSelectionSheet: View {
       )
     }
 
-    return stationDistances.sorted { a, b in
+    sortedStationEntries = stationDistances.sorted { a, b in
       if a.station.pinned != b.station.pinned {
         return a.station.pinned && !b.station.pinned
       }
@@ -84,6 +90,13 @@ struct StationSelectionSheet: View {
     }
     .onAppear {
       tapHaptic.prepare()
+      updateSortedStationEntries()
+    }
+    .onChange(of: searchTerm) { _ in
+      updateSortedStationEntries()
+    }
+    .onChange(of: stations) { _ in
+      updateSortedStationEntries()
     }
   }
 }


### PR DESCRIPTION
## Summary
- avoid recomputing station distances on every render
- cache sorted station list and update when search terms or data change

## Testing
- `git status --short`