### PR TITLE
Improve station list rendering

### DIFF
--- a/Sources/Utilities/FormatterUtils.swift
+++ b/Sources/Utilities/FormatterUtils.swift
@@ -10,7 +10,11 @@ func formatTimeInterval(interval: TimeInterval) -> String {
 }
 
 func formattedDistanceTraveled(distance: CLLocationDistance) -> String {
-  let distanceFormatter = MKDistanceFormatter()
-  distanceFormatter.unitStyle = .full
   return distanceFormatter.string(fromDistance: distance)
 }
+
+private let distanceFormatter: MKDistanceFormatter = {
+  let formatter = MKDistanceFormatter()
+  formatter.unitStyle = .full
+  return formatter
+}()


### PR DESCRIPTION
## Summary
- reduce per-row work by precomputing station service alerts and distance
- update station list when alerts change
- reuse a single `MKDistanceFormatter` instance

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `git status --short`