### PR TITLE
Add PostHog usage logging

### DIFF
--- a/Sources/Utilities/LoggingUtils.swift
+++ b/Sources/Utilities/LoggingUtils.swift
@@ -6,3 +6,48 @@ func logStationSignTapped(for station: MTAStation) {
     "user_tapped_station_sign",
     properties: ["currentStation": station.name])
 }
+
+func logStationSelected(_ station: MTAStation) {
+  PostHogSDK.shared.capture(
+    "user_selected_station",
+    properties: ["station": station.name])
+}
+
+func logDirectionChanged(_ direction: TripDirection, station: MTAStation?) {
+  var props: [String: String] = ["direction": direction.rawValue]
+  if let stationName = station?.name {
+    props["station"] = stationName
+  }
+  PostHogSDK.shared.capture("user_changed_direction", properties: props)
+}
+
+func logRefresh(for station: MTAStation?) {
+  if let stationName = station?.name {
+    PostHogSDK.shared.capture(
+      "data_refresh",
+      properties: ["station": stationName])
+  } else {
+    PostHogSDK.shared.capture("data_refresh")
+  }
+}
+
+func logSearch(term: String) {
+  PostHogSDK.shared.capture(
+    "station_search",
+    properties: ["term": term])
+}
+
+func logPinToggled(for station: MTAStation, pinned: Bool) {
+  PostHogSDK.shared.capture(
+    "station_pin_toggled",
+    properties: [
+      "station": station.name,
+      "pinned": String(pinned)
+    ])
+}
+
+func logServiceAlertsViewed(for station: MTAStation) {
+  PostHogSDK.shared.capture(
+    "service_alerts_viewed",
+    properties: ["station": station.name])
+}

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -55,7 +55,7 @@ struct ContentView: View {
           Text(TripDirection.south.rawValue).tag(TripDirection.south)
           Text(TripDirection.north.rawValue).tag(TripDirection.north)
         }.pickerStyle(.segmented).labelsHidden().padding(.bottom, 8)
-
+        
         List(visibleArrivals) { arrival in
           ArrivalCard(arrival: arrival).listRowInsets(
             EdgeInsets(
@@ -88,8 +88,13 @@ struct ContentView: View {
       if selectedStation != nil { return }
       setNearestStation()
       Task { await refreshData() }
-    }.onChange(of: selectedStation) {
+    }.onChange(of: selectedStation) { newValue in
+      if let station = newValue {
+        logStationSelected(station)
+      }
       Task { await refreshData() }
+    }.onChange(of: selectedDirection) { newDirection in
+      logDirectionChanged(newDirection, station: selectedStation ?? nearestStation)
     }.sheet(isPresented: $selectionSheetActive) {
       StationSelectionSheet(
         location: locationFetcher.location,
@@ -112,6 +117,8 @@ struct ContentView: View {
     guard let station = selectedStation ?? nearestStation else {
       return
     }
+
+    logRefresh(for: station)
 
     let lines = station.lines
     let stops = station.stops.map { MTAStopValue(mtaStop: $0) }

--- a/Sources/Views/PinButton.swift
+++ b/Sources/Views/PinButton.swift
@@ -21,6 +21,7 @@ struct PinButton: View {
         modelContext.insert(station)
         try! modelContext.save()
       }
+      logPinToggled(for: station, pinned: station.pinned)
     } label: {
       Image(systemName: "heart.fill")
         .frame(height: 22)

--- a/Sources/Views/StationSelectionSheet.swift
+++ b/Sources/Views/StationSelectionSheet.swift
@@ -69,6 +69,7 @@ struct StationSelectionSheet: View {
             tapHaptic.impactOccurred()
             selectedStation = entry.station
             isPresented = false
+            logStationSelected(entry.station)
           }
           .shadow(radius: 2)
       }
@@ -92,7 +93,10 @@ struct StationSelectionSheet: View {
       tapHaptic.prepare()
       updateSortedStationEntries()
     }
-    .onChange(of: searchTerm) { _ in
+    .onChange(of: searchTerm) { newTerm in
+      if !newTerm.isEmpty {
+        logSearch(term: newTerm)
+      }
       updateSortedStationEntries()
     }
     .onChange(of: stations) { _ in

--- a/Sources/Views/StationSign.swift
+++ b/Sources/Views/StationSign.swift
@@ -93,11 +93,15 @@ struct StationSign: View {
 
     }.cornerRadius(8)
       .sheet(isPresented: $alertSheetActive) {
-        AlertSheet(serviceAlerts: serviceAlerts).presentationDetents([
-          .medium, .large,
-        ])
-        .presentationDragIndicator(.visible)
-        .presentationBackground(.thickMaterial)
+        AlertSheet(serviceAlerts: serviceAlerts)
+          .presentationDetents([
+            .medium, .large,
+          ])
+          .presentationDragIndicator(.visible)
+          .presentationBackground(.thickMaterial)
+          .onAppear {
+            logServiceAlertsViewed(for: station)
+          }
       }
   }
 }


### PR DESCRIPTION
## Summary
- add helper functions for additional PostHog events
- track station selection and direction changes
- log refresh and search events
- capture pin toggles and service alert views

## Testing
- `swift test --package-path Tests` *(fails: invalid custom path 'Utilities')*