### PR TITLE
Fix concurrency and compile issues

### DIFF
--- a/Sources/Models/MTAStation.swift
+++ b/Sources/Models/MTAStation.swift
@@ -40,7 +40,7 @@ class MTAStation {
   }
 
   var lines: [MTALine] {
-    return self.daytimeRoutes.map(\.line).uniqued()
+    return Array(self.daytimeRoutes.map(\.line).uniqued())
   }
 }
 

--- a/Sources/Utilities/FormatterUtils.swift
+++ b/Sources/Utilities/FormatterUtils.swift
@@ -12,12 +12,8 @@ func formatTimeInterval(interval: TimeInterval) -> String {
   timeIntervalFormatter.string(from: interval) ?? ""
 }
 
-private let distanceFormatter: MKDistanceFormatter = {
+func formattedDistanceTraveled(distance: CLLocationDistance) -> String {
   let formatter = MKDistanceFormatter()
   formatter.unitStyle = .full
-  return formatter
-}()
-
-func formattedDistanceTraveled(distance: CLLocationDistance) -> String {
-  distanceFormatter.string(fromDistance: distance)
+  return formatter.string(fromDistance: distance)
 }


### PR DESCRIPTION
## Summary
- remove global MKDistanceFormatter to avoid Sendable warning
- fix `MTAStation.lines` return type

## Testing
- `swift test --package-path Tests`

------
https://chatgpt.com/codex/tasks/task_e_683bef735ea083308e55fd4c61c8aeef