### PR TITLE
Show station-specific direction labels

### DIFF
--- a/Sources/Models/MTAStation.swift
+++ b/Sources/Models/MTAStation.swift
@@ -42,6 +42,32 @@ class MTAStation {
   var lines: [MTALine] {
     return Array(self.daytimeRoutes.map(\.line).uniqued())
   }
+
+  func getLabelFor(direction: TripDirection) -> String {
+    let labels = Set(self.stops.map { $0.getLabelFor(direction: direction) })
+      .filter { !$0.isEmpty }
+
+    if labels.isEmpty {
+      return direction.rawValue
+    }
+
+    // Combine common borough labels the way the MTA styles them
+    if labels.contains("Downtown") && labels.contains("Brooklyn") {
+      return "Downtown & Brooklyn"
+    }
+    if labels.contains("Uptown") && labels.contains("The Bronx") {
+      return "Uptown & The Bronx"
+    }
+    if labels.contains("Uptown") && labels.contains("Queens") {
+      return "Uptown & Queens"
+    }
+
+    if labels.count == 1, let only = labels.first {
+      return only
+    }
+
+    return labels.sorted().joined(separator: " & ")
+  }
 }
 
 extension MTAStation {

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -52,8 +52,12 @@ struct ContentView: View {
 
       VStack {
         Picker("", selection: $selectedDirection) {
-          Text(TripDirection.south.rawValue).tag(TripDirection.south)
-          Text(TripDirection.north.rawValue).tag(TripDirection.north)
+          let southLabel = visibleStation?.getLabelFor(direction: .south)
+            ?? TripDirection.south.rawValue
+          let northLabel = visibleStation?.getLabelFor(direction: .north)
+            ?? TripDirection.north.rawValue
+          Text(southLabel).tag(TripDirection.south)
+          Text(northLabel).tag(TripDirection.north)
         }.pickerStyle(.segmented).labelsHidden().padding(.bottom, 8)
         
         List(visibleArrivals) { arrival in


### PR DESCRIPTION
## Summary
- add a helper to derive a station's north/south labels
- use station labels for the direction picker
- style direction labels with ampersands like MTA signage

## Testing
- `swift test --package-path Tests` *(fails: invalid custom path 'Utilities' for target 'EncodingUtils')*

------
https://chatgpt.com/codex/tasks/task_e_683bf3e337088330a39c910e6cd5cb34