### PR TITLE
Add favorites filter to station picker

### DIFF
--- a/Sources/Views/StationSelectionSheet.swift
+++ b/Sources/Views/StationSelectionSheet.swift
@@ -8,11 +8,19 @@ struct StationWithDistance: Identifiable {
   var id: MTAStation.ID { station.id }
 }
 
+enum StationFilter: String, CaseIterable, Identifiable {
+  case nearby = "Nearby"
+  case favorites = "Favorites"
+
+  var id: Self { self }
+}
+
 struct StationSelectionSheet: View {
   @Query var stations: [MTAStation]
 
   var location: CLLocation?
   @State private var searchTerm = ""
+  @State private var selectedFilter: StationFilter = .nearby
   @Binding var isPresented: Bool
   @Binding var selectedStation: MTAStation?
 
@@ -21,10 +29,16 @@ struct StationSelectionSheet: View {
   let tapHaptic = UIImpactFeedbackGenerator(style: .medium)
 
   var filteredStationEntries: [MTAStation] {
-    guard !searchTerm.isEmpty else { return stations }
-    return stations.filter {
-      $0.name.localizedCaseInsensitiveContains(searchTerm)
+    var filtered = stations
+    if selectedFilter == .favorites {
+      filtered = filtered.filter(\.pinned)
     }
+    if !searchTerm.isEmpty {
+      filtered = filtered.filter {
+        $0.name.localizedCaseInsensitiveContains(searchTerm)
+      }
+    }
+    return filtered
   }
 
   var sortedStationEntries: [StationWithDistance] {
@@ -48,7 +62,17 @@ struct StationSelectionSheet: View {
   var body: some View {
 
     NavigationView {
-      List(sortedStationEntries) { entry in
+      VStack {
+        Picker("Filter", selection: $selectedFilter) {
+          ForEach(StationFilter.allCases) { filter in
+            Text(filter.rawValue).tag(filter)
+          }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .padding([.horizontal, .top])
+
+        List(sortedStationEntries) { entry in
         let alertsForStation: [MTAServiceAlert] = entry.station.stops
           .compactMap { stop in
             serviceAlerts[stop.gtfsStopID]
@@ -67,20 +91,21 @@ struct StationSelectionSheet: View {
             logStationSelected(entry.station)
           }
           .shadow(radius: 2)
-      }
-      .listStyle(.plain)
-      .searchable(
-        text: $searchTerm,
-        placement: .automatic,
-        prompt: "Search stations"
-      )
-      .overlay {
-        if sortedStationEntries.isEmpty, !searchTerm.isEmpty {
-          ContentUnavailableView.search(text: searchTerm)
+        }
+        .listStyle(.plain)
+        .searchable(
+          text: $searchTerm,
+          placement: .automatic,
+          prompt: "Search stations"
+        )
+        .overlay {
+          if sortedStationEntries.isEmpty, !searchTerm.isEmpty {
+            ContentUnavailableView.search(text: searchTerm)
+          }
         }
       }
       .navigationBarTitle(
-        "Nearby Stations",
+        selectedFilter == .favorites ? "Favorite Stations" : "Nearby Stations",
         displayMode: .inline
       )
     }


### PR DESCRIPTION
## Summary
- add segmented picker to filter stations by Favorites or Nearby
- show "Favorite Stations" title when appropriate

## Testing
- `swift test` *(fails: 'tests': invalid custom path 'Utilities' for target 'EncodingUtils')*

------
https://chatgpt.com/codex/tasks/task_e_683c033921e08330920fdbfa99bf2475